### PR TITLE
Specify args to setup script at install

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ sudo pip install pymakeself
 The pymakeself package installs the `pymakeself` command.  This is the same as running `python -m pymakeself`, and has the following syntax:
 
 ```
-pymakeself [args] content_dir file_name setup_script [script_args]
+pymakeself [args] content_dir file_name setup_script [setup_args]
 ```
 The `args` beginning with `-` or `--` are optional.  The available options are:
 
@@ -57,6 +57,8 @@ The `args` beginning with `-` or `--` are optional.  The available options are:
 
 `setup_script` is a Python script to be executed from within the extracted content directory, that is run using the same Python interpreter used to run the installer.  If the script is already located inside the content directory then only specify the name of the script.  Otherwise, provide a relative or absolute path to the script so that it can be copied into the installer archive.  The special value `@accountutil` tells pymakeself to use the Unix [account creation tool](https://github.com/gammazero/pymakeself/blob/master/pymakeself/installtools/accountutil.py), included in the pymakeself package, as the `setup_script`.
 
+`setup_args` are optional arguments to pass into Python setup script when run during execution of the installer.  Additional arguments can also be specified on the command line when running the installer.
+
 Here is an example, assuming the user has a package image stored in a `/home/jane/mysoft`, and wants to generate a self-extracting package named install_mysoft.py, which will launch the `setup.py` script initially stored in `/home/jane/mysoft`:
 ```
 pymakeself.py --label "Jane's Nice Software Package" /home/jane/mysoft install_mysoft setup.py
@@ -67,7 +69,7 @@ Here is how I created a `install_pymakeself.py` installer that installs the pyma
 pymakeself --label "PyMakeSelf by Andrew Gillis" pymakeself install_pymakeself setup.py install
 ```
 
-Archives generated with pymakeself can be passed the following arguments:
+Self-extracting archives generated with pymakeself can be passed the following arguments:
 
 `--check` : Check the integrity of the archive by verifying the embedded SHA256 checksum.  Does not extract the archive.
 
@@ -75,16 +77,23 @@ Archives generated with pymakeself can be passed the following arguments:
 
 `--extract` : Extract package contents to temporary directory and exit.
 
-Any subsequent arguments to the archive will be passed as additional arguments to the embedded command.
+Any other command line arguments given to the self-extracting archive are passed as arguments to the embedded setup script.
 
 ## Examples
 
+### Installer with Setup Script
 Create an installer, named install_stuff, that runs setup.py:
 
 ```
 pymakeself /storage/myfiles install_stuff setup.py
 ```
 
+Run the installer to install the content and run the setup.py script.  Notice that additional arguments are passed to the setup script at install time:
+```
+python install_stuff.py --logdir /var/log/mystuff
+```
+
+### Install User Account
 Create an installer that runs the `accountutil.py` tool (one of the modules in the pymakeself installtools) as the setup script, to create the "ajg" user account:
 ```
 pymakeself ~/ajg_dot_files create_ajg @accountutil \

--- a/pymakeself/makeself.py
+++ b/pymakeself/makeself.py
@@ -71,7 +71,7 @@ try:
 except ImportError:
     pass
 
-__version__ = '0.3.4'
+__version__ = '0.3.5'
 
 _exe_template = \
 b"""
@@ -94,6 +94,8 @@ def main():
                     help='List the files in the archive')
     ap.add_argument('--extract', action='store_true',
                     help='Extract package contents and exit')
+    ap.add_argument('args', nargs=argparse.REMAINDER,
+                    help='Arguments to pass to setup script')
     args = ap.parse_args()
 
     tmp_dir = None
@@ -218,6 +220,8 @@ def main():
 
             sys.argv = [script_name]
             sys.argv.extend(script_args)
+            if args.args:
+                sys.argv.extend(args.args)
             with open(script_name) as f:
                 code = compile(f.read(), script_name, 'exec')
 

--- a/tests/test_simpleinstall.py
+++ b/tests/test_simpleinstall.py
@@ -64,7 +64,11 @@ class TestSimpleInstall(object):
     def test_list_installer(self):
         """Test files list."""
         files = []
-        o = subprocess.check_output(('python', self.installer_name, '--list'))
+        kwargs = {}
+        if sys.version_info.major >= 3:
+            kwargs = {"text": True}
+        o = subprocess.check_output(('python', self.installer_name, '--list'),
+                                    **kwargs)
         for line in o.split('\n'):
             if line and line[0] == '-':
                 files.append(line.split()[-1])
@@ -77,7 +81,8 @@ class TestSimpleInstall(object):
     def test_run_installer(self):
         """Test running installer."""
         # Run the installer.
-        subprocess.check_call(('python', self.installer_name))
+        subprocess.check_call(('python', self.installer_name,
+                               "hello", "world", "--xyz"))
         print('Ran', self.installer_name)
 
         # Make sure all the expected files are in the install dir.
@@ -101,5 +106,5 @@ class TestSimpleInstall(object):
             params_data = fin.read().strip()
         assert params_data
         params = params_data.split(',')
-        assert params == self.setup_args
+        assert params == self.setup_args + ["hello", "world", "--xyz"]
         print('Setup arguments were correctly supplied to installer.')


### PR DESCRIPTION
When running the self-extracting archive, allow user to specify arguments to pass to the setup script.

FIxed Issue #6 