### PR TITLE
Base64 update

### DIFF
--- a/pymakeself/makeself.py
+++ b/pymakeself/makeself.py
@@ -138,7 +138,7 @@ def main():
             # Write the aes tarfile to disk.
             aes_path = os.path.join(tmp_dir, 'aes.tar.gz')
             with open(aes_path, 'wb') as fp:
-                if sys.verion_info >= (3, 1) :
+                if sys.version_info >= (3, 1) :
                     fp.write(base64.decodebytes(AES_PKG_DATA))
                 else :
                     fp.write(base64.decodestring(AES_PKG_DATA))

--- a/pymakeself/makeself.py
+++ b/pymakeself/makeself.py
@@ -107,7 +107,10 @@ def main():
         # Write the tarfile into the temporary directory
         tar_path = os.path.join(tmp_dir, tar_name)
         with open(tar_path, 'wb') as fp:
-            fp.write(base64.decodestring(PKG_DATA))
+            if sys.version_info >= (3, 1) :
+                fp.write(base64.decodebytes(PKG_DATA))
+            else :
+                fp.write(base64.decodestring(PKG_DATA))
 
         if sha256_sum:
             import hashlib
@@ -135,7 +138,10 @@ def main():
             # Write the aes tarfile to disk.
             aes_path = os.path.join(tmp_dir, 'aes.tar.gz')
             with open(aes_path, 'wb') as fp:
-                fp.write(base64.decodestring(AES_PKG_DATA))
+                if sys.verion_info >= (3, 1) :
+                    fp.write(base64.decodebytes(AES_PKG_DATA))
+                else :
+                    fp.write(base64.decodestring(AES_PKG_DATA))
             # Unpack the aes tarfile then delete it.
             with tarfile.open(aes_path) as t:
                 t.extractall(tmp_dir)


### PR DESCRIPTION
**Bug Fix**

This PR is required to allow pymakeself to work with Python post 3.9...

The current version of pymakeself makes use of the depreciated base64.decodestring method which was *removed* in Python 3.9.

This PR adds a check for python version, and if the version is later than 3.1 it uses the base54.decodebytes method.

(I have tested this on my own archive using my "merged_main" branch.)

Thanks for a very useful tool!