### PR TITLE
added orig_dir as global to the execution of the setup_script

### DIFF
--- a/pymakeself/makeself.py
+++ b/pymakeself/makeself.py
@@ -230,7 +230,7 @@ def main():
                 # it was not located in archive dir.
                 os.chdir(arch_path)
 
-            exec(code, {'__name__': '__main__', '__file__': script_name})
+            exec(code, {'__name__': '__main__', '__file__': script_name, '__orig_dir__' : orig_dir})
             # *** DO NO EXPECT EXECUTION PAST THIS POINT ***
             # setup script may call sys.exit()
     except RuntimeError as e:


### PR DESCRIPTION
**Feature request**

**use case**: 
I would like to extract the contents of the pymakeself archive into a subdirectory of the directory in which I invoke the pymakeself archive.

**current problem**:
The current pymakeself does not inform the embedded setup_script of the location of the "orig_dir" in which the pymakeself archive itself is being run.

**solution**:
I have added an additional global variable `__orig_dir__` which contains the original directory in which the pymakeself archive is being invoked.
